### PR TITLE
PLT-2961  <harshith>removed null resource dependency in s3 bucket logging

### DIFF
--- a/aws/modules/s3/main.tf
+++ b/aws/modules/s3/main.tf
@@ -58,8 +58,6 @@ resource "aws_s3_bucket_logging" "my_protected_bucket_logging" {
 
   target_bucket = aws_s3_bucket.my_protected_bucket.id
   target_prefix = "bucket-logs/"
-
-  depends_on = [ null_resource.waiting ]
 }
 
 # Resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"

--- a/aws_workspace/modules/s3/main.tf
+++ b/aws_workspace/modules/s3/main.tf
@@ -58,8 +58,6 @@ resource "aws_s3_bucket_logging" "my_protected_bucket_logging" {
 
   target_bucket = aws_s3_bucket.my_protected_bucket.id
   target_prefix = "bucket-logs/"
-
-  depends_on = [ null_resource.waiting ]
 }
 
 # Resource to avoid error "AccessControlListNotSupported: The bucket does not allow ACLs"


### PR DESCRIPTION
Referring the official terraform doc, there is no neccessity of any depend on block for s3 bucket logging. I have tested the same https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging